### PR TITLE
Add Support for 6.x Kernels

### DIFF
--- a/octoprint_opitemp/__init__.py
+++ b/octoprint_opitemp/__init__.py
@@ -62,7 +62,7 @@ class OpitempPlugin(octoprint.plugin.SettingsPlugin,
                                    + " are you sure you're using Armbian?")
                 return
             # lazy fix for #3, yeah I known...
-            if platform.release().startswith("4") or platform.release().startswith("5") or latform.release().startswith("6"):
+            if platform.release().startswith("4") or platform.release().startswith("5") or platform.release().startswith("6"):
                 self.temp = "{0:.1f}".format(float(match.group(1))/1000)
             elif platform.release().startswith("3"):
                 self.temp = match.group(1)

--- a/octoprint_opitemp/__init__.py
+++ b/octoprint_opitemp/__init__.py
@@ -62,7 +62,7 @@ class OpitempPlugin(octoprint.plugin.SettingsPlugin,
                                    + " are you sure you're using Armbian?")
                 return
             # lazy fix for #3, yeah I known...
-            if platform.release().startswith("4") or platform.release().startswith("5"):
+            if platform.release().startswith("4") or platform.release().startswith("5") or latform.release().startswith("6"):
                 self.temp = "{0:.1f}".format(float(match.group(1))/1000)
             elif platform.release().startswith("3"):
                 self.temp = match.group(1)


### PR DESCRIPTION
Armbian has gone to Kernel 6.x (here 6.1.x) for Orange Pi (at least the Zero if have)
Requires minor change in check_temp()
